### PR TITLE
twitter:image:alt 対応

### DIFF
--- a/src/pages/images/[iid].tsx
+++ b/src/pages/images/[iid].tsx
@@ -75,7 +75,7 @@ const Meta: VFC<{ data: Success }> = ({ data }) => {
         name="twitter:image"
         content={`${origin}/images/${data.detail.imageName}`}
       />
-      <meta　name="twitter:image:alt"　content={data.detail.name}　/>
+      <meta name="twitter:image:alt" content={data.detail.name} />
     </Head>
   );
 };

--- a/src/pages/images/[iid].tsx
+++ b/src/pages/images/[iid].tsx
@@ -75,6 +75,7 @@ const Meta: VFC<{ data: Success }> = ({ data }) => {
         name="twitter:image"
         content={`${origin}/images/${data.detail.imageName}`}
       />
+      <meta　name="twitter:image:alt"　content={data.detail.name}　/>
     </Head>
   );
 };


### PR DESCRIPTION
OGP画像の代替テキスト対応です。

参考：https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup